### PR TITLE
Add points share to SongInfo

### DIFF
--- a/Analyzer.fs
+++ b/Analyzer.fs
@@ -88,9 +88,31 @@ type Analyzer(songs: seq<SongInfo>, votes: seq<VoteInfo>) =
 
     member _.WriteSongs() =
         Console.WriteLine "Writing songs.csv";
+
+        let pointsBySong =
+            votes
+            |> Seq.groupBy (fun v -> v.SongId)
+            |> Seq.map (fun (k, vs) -> k, vs |> Seq.sumBy (fun v -> v.Points) |> float)
+            |> Map.ofSeq
+
+        let pointsByRound =
+            votes
+            |> Seq.groupBy (fun v -> v.RoundId)
+            |> Seq.map (fun (k, vs) -> k, vs |> Seq.sumBy (fun v -> v.Points) |> float)
+            |> Map.ofSeq
+
+        let songsWithShare =
+            songs
+            |> Seq.map (fun s ->
+                let songPoints = pointsBySong |> Map.tryFind s.SongId |> Option.defaultValue 0.0
+                let roundPoints = pointsByRound |> Map.tryFind s.RoundId |> Option.defaultValue 0.0
+                let share = if roundPoints = 0.0 then 0.0 else songPoints / roundPoints
+                SongInfo(s.LeagueName, s.RoundName, s.SongName, s.ArtistName, s.AlbumName, s.PostedBy, s.SongLink, s.Position, s.SongId, s.RoundId, share)
+            )
+
         use writer = new StreamWriter "songs.csv"
         use csv = new CsvWriter(writer, CultureInfo.InvariantCulture)
-        csv.WriteRecords songs
+        csv.WriteRecords songsWithShare
 
     member _.WriteVoteCosineSimilarity() =
         let dotProduct seq1 seq2 = Seq.map2 (fun a b -> a * b) seq1 seq2 |> Seq.sum

--- a/Downloader.fs
+++ b/Downloader.fs
@@ -125,7 +125,7 @@ type Downloader(hostName: string, cookie: string, leagueNameFilter: string, noCa
                     let postedBy = songXml |> selectElementText resultsPostedByPath
 
                     (
-                        SongInfo(leagueName, roundName, songName, artistName, albumName, postedBy, songLink, index + 1, songId, roundLink),
+                        SongInfo(leagueName, roundName, songName, artistName, albumName, postedBy, songLink, index + 1, songId, roundLink, 0.0),
 
                         songXml
                         |> selectSingleElement ".//div[starts-with(@id, 'votes-')]"

--- a/SongInfo.fs
+++ b/SongInfo.fs
@@ -1,18 +1,19 @@
 namespace VoteAnalyzer
 
-type SongInfo =
-    struct
-        val LeagueName: string
-        val RoundName: string
-        val Position: int
-        val PostedBy: string
-        val SongLink: string
-        val SongName: string
-        val ArtistName: string
-        val AlbumName: string
-        val SongId : string
-        val RoundId : string
+    type SongInfo =
+        struct
+            val LeagueName: string
+            val RoundName: string
+            val Position: int
+            val PostedBy: string
+            val SongLink: string
+            val SongName: string
+            val ArtistName: string
+            val AlbumName: string
+            val SongId : string
+            val RoundId : string
+            val PointsShare : float
 
-        new(leagueName: string, roundName: string, songName: string, artistName: string, albumName: string, postedBy: string, songLink: string, position: int, songId : string, roundId: string) =
-            { LeagueName = leagueName; RoundName = roundName; SongName = songName; ArtistName = artistName; AlbumName = albumName; PostedBy = postedBy; SongLink = songLink; Position = position; SongId = songId; RoundId = roundId }
-    end
+            new(leagueName: string, roundName: string, songName: string, artistName: string, albumName: string, postedBy: string, songLink: string, position: int, songId : string, roundId: string, pointsShare: float) =
+                { LeagueName = leagueName; RoundName = roundName; SongName = songName; ArtistName = artistName; AlbumName = albumName; PostedBy = postedBy; SongLink = songLink; Position = position; SongId = songId; RoundId = roundId; PointsShare = pointsShare }
+        end


### PR DESCRIPTION
## Summary
- support storing percentage of points for each song per round
- populate the value when exporting songs

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845334abe5483219811e7686e068abb